### PR TITLE
Improve blog post readability

### DIFF
--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -17,13 +17,16 @@
 .date {
   font-weight: 300;
   font-size: 1rem;
-  color: #808080;
+  color: #9a9a9a;
 }
 
 .container {
   display: flex;
   flex-direction: column;
   width: 50%;
+  /* Cap the measure at ~70 characters; percentage widths alone give
+     130+ character lines on large screens */
+  max-width: 40rem;
   margin: auto;
 
   border-bottom: 2px solid #3a3a3a;
@@ -81,6 +84,7 @@
   display: flex;
   flex-direction: row;
   width: 50%;
+  max-width: 40rem; /* stay aligned with .container */
   justify-content: space-between;
   margin: auto;
 }
@@ -135,20 +139,19 @@
   /* Readability improvements */
   margin-top: 2vh;
 
-  line-height: 1.5;
-  letter-spacing: 0.01em;
+  font-size: 1.125rem;
+  line-height: 1.65;
 }
 
 .body p {
-  text-align: justify;
   margin-bottom: 1.5em;
   margin-top: 0;
 }
 
 .body h1 {
   position: relative;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin-top: 2em;
+  margin-bottom: 0.75em;
   font-weight: bold;
   line-height: 1.4;
   cursor: text;
@@ -163,14 +166,18 @@
 .body h2 {
   font-size: 1.75em;
   line-height: 1.225;
+  /* More space above than below attaches the heading to its section */
+  margin-top: 1.75em;
+  margin-bottom: 0.75em;
+  padding-bottom: 0.25em;
   border-bottom: 1px solid #3a3a3a;
 }
 
 .body h3 {
   font-size: 1.5em;
   line-height: 1.3;
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
   font-weight: 600;
   color: #f0f0f0;
 }
@@ -308,12 +315,7 @@
   }
 
   .body {
-    font-size: 16px;
+    font-size: 1.0625rem;
     max-width: 100%;
-    letter-spacing: 0.01em;
-  }
-
-  .body p {
-    text-align: left; /* Remove justification on mobile */
   }
 }


### PR DESCRIPTION
## What

The typography fixes from the readability audit, kept separate so they can be judged visually in isolation. One file changed: `web/styles/Post.module.css`, blog posts only.

- **Line length**: article column capped at `max-width: 40rem` (~70 characters per line at the new size). Previously `width: 50%` of the viewport gave ~95 chars on a 1440px screen, ~130 on 1920px; the comfortable range is 45–75. `.nav-buttons` gets the same cap to stay aligned.
- **No more justified text**: browsers justify without hyphenation, which stretches word spacing unevenly ("rivers"). Left-aligned ragged-right instead; the mobile-only left-align override is now redundant and removed.
- **Body text**: 16px/1.5 → **18px/1.65** (17px on mobile). Removed the `letter-spacing: 0.01em` — tracking helps caps headings, not body text.
- **Heading rhythm**: H1/H2 now get ~2× more space above than below, so headings attach visually to the section they introduce instead of floating between sections. H3 margins converted to em to scale with the new body size.
- **Meta contrast**: post date lifted from `#808080` to `#9a9a9a`.

## Verification
- `next build` prerenders all 42 pages cleanly.
- Best reviewed by eyeballing a long post (e.g. a course-review post) on a wide screen, before/after.

## Notes
- Merges independently of #15; both touch `Post.module.css` in different places, so whichever lands second may need a trivial rebase.