### PR TITLE
Scale post typography to Medium/Substack proportions

### DIFF
--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -24,9 +24,9 @@
   display: flex;
   flex-direction: column;
   width: 50%;
-  /* Cap the measure at ~70 characters; percentage widths alone give
-     130+ character lines on large screens */
-  max-width: 40rem;
+  /* Medium/Substack scale: ~680px column at 20px type ≈ 65 chars/line.
+     Percentage widths alone give 130+ character lines on large screens */
+  max-width: 42.5rem;
   margin: auto;
 
   border-bottom: 2px solid #3a3a3a;
@@ -84,7 +84,7 @@
   display: flex;
   flex-direction: row;
   width: 50%;
-  max-width: 40rem; /* stay aligned with .container */
+  max-width: 42.5rem; /* stay aligned with .container */
   justify-content: space-between;
   margin: auto;
 }
@@ -139,8 +139,8 @@
   /* Readability improvements */
   margin-top: 2vh;
 
-  font-size: 1.125rem;
-  line-height: 1.65;
+  font-size: 1.25rem;
+  line-height: 1.6;
 }
 
 .body p {
@@ -315,7 +315,7 @@
   }
 
   .body {
-    font-size: 1.0625rem;
+    font-size: 1.125rem;
     max-width: 100%;
   }
 }


### PR DESCRIPTION
## What

Follow-up to #16, which landed the right *measure* (~70 characters/line) at the wrong *scale* — 18px type in a 640px column reads as a narrow strip of small text.

Medium (~680px column, 21px body) and Substack (~680px, 20px) use the same character count per line, just bigger: the column feels generous because the type fills it.

- Body text: 18px/1.65 → **20px/1.6** (mobile: 17px → 18px)
- Column: 640px → **680px** max-width (nav buttons follow)

Character count per line stays ~65; everything scales up ~11%. Headings, code, and captions are em-based so they scale automatically.

## Verification
- `next build` prerenders all 42 pages cleanly.
- Judge on a long post at desktop width.