### PR TITLE
Smarten punctuation in rendered post prose

### DIFF
--- a/web/components/PostContent.js
+++ b/web/components/PostContent.js
@@ -21,6 +21,38 @@ function urlFor(source) {
     return createImageUrlBuilder(client).image(source);
 }
 
+// Typographic finishing for prose: typewriter marks read as typos in a
+// serif face. Source content in Sanity stays untouched.
+function smarten(text) {
+    return text
+        .replace(/(\w)'(\w)/g, '$1’$2') // contractions: it's -> it’s
+        .replace(/'(\d)/g, '’$1') // decades: '90s
+        .replace(/(^|[\s([])'(\S)/g, '$1‘$2') // opening single quote
+        .replace(/'/g, '’') // remaining singles close: years', 'twas
+        .replace(/(^|[\s([])"(\S)/g, '$1“$2') // opening double quote
+        .replace(/"/g, '”') // remaining doubles close
+        .replace(/(\d) - (\d)/g, '$1–$2') // numeric range -> en dash
+        .replace(/ - /g, ' — '); // spaced hyphen -> em dash
+}
+
+function smartenBody(body) {
+    return body.map((block) => {
+        if (block._type !== 'block' || !Array.isArray(block.children)) {
+            return block;
+        }
+        return {
+            ...block,
+            children: block.children.map((child) =>
+                child._type === 'span' &&
+                typeof child.text === 'string' &&
+                !child.marks?.includes('code')
+                    ? { ...child, text: smarten(child.text) }
+                    : child
+            ),
+        };
+    });
+}
+
 // Stable anchor ids for headings, derived from their text
 function headingId(value) {
     const text = value.children?.map((child) => child.text ?? '').join('') ?? '';
@@ -155,7 +187,7 @@ const PostContent = ({ post }) => {
                 </span>
 
                 <div className={styles.body}>
-                    <ReactPortableText value={body} components={ptComponents} />
+                    <ReactPortableText value={smartenBody(body)} components={ptComponents} />
                 </div>
 
                 <span className={styles.categories}>


### PR DESCRIPTION
## What

The serif follow-up we discussed: Literata exposed typewriter punctuation (`it's`, `filler - I`) that Roboto used to hide. This adds a ~25-line render-time pass over Portable Text spans:

- `'` → `'` in contractions and possessives; `'90s`; quote pairs `'…'`
- `\"…\"` → `“…”`
- `word - word` → `word — word` (em dash); `1 - 5` → `1–5` (en dash)

Applies to every existing and future post at once. **Sanity source content is untouched** — this happens at render. Spans marked as inline code are skipped, and LaTeX/code blocks are separate node types so they can't be affected. Meta descriptions intentionally stay raw.

## Verification
- Unit-tested the transform on edge cases (contractions, decades, quote pairs, numeric ranges, multiple dashes in one sentence).
- Built and inspected prerendered HTML of the course-review post: article text now reads `weren’t`, `filler — I`; only meta tags and the hydration payload (which must mirror the source) retain raw marks.
- `next build` clean, 42 pages.

## Notes
- If you ever type a proper `’` or `—` yourself in Sanity, the pass leaves it alone — rules only match the straight/spaced forms.