### PR TITLE
Render post articles on the server

### DIFF
--- a/web/components/Latex.js
+++ b/web/components/Latex.js
@@ -1,8 +1,7 @@
-"use client";
-
 import katex from 'katex';
 
-// Renders raw LaTeX (without $/$$ delimiters) via KaTeX.
+// Renders raw LaTeX (without $/$$ delimiters) via KaTeX. Pure string
+// rendering, so it runs on the server and KaTeX never ships to the client.
 const Latex = ({ children, displayMode = false }) => {
     const html = katex.renderToString(children ?? '', {
         displayMode,

--- a/web/components/PostContent.js
+++ b/web/components/PostContent.js
@@ -1,4 +1,6 @@
-"use client"; // PortableText needs to be a client component if using custom client components like Latex or PDFViewer
+// Server component: Portable Text renders to HTML on the server; only the
+// interactive leaves (PDFViewer, CodeBlock, FormattedDate, Header) are
+// client components and ship JS.
 
 import styles from '../styles/Post.module.css'; // Corrected path
 import client from '../client'; // Corrected path


### PR DESCRIPTION
## What

The client/server split from the original audit. `PostContent` was `"use client"` wholesale — every visitor downloaded PortableText, KaTeX, and all the article-rendering code just to hydrate HTML that SSG had already produced.

- `PostContent` is now a server component; the interactive leaves (`PDFViewer`, `CodeBlock`'s copy button, `FormattedDate`, `Header`) keep their own `"use client"` and are the only parts that ship JS.
- `Latex` also drops its client directive: `katex.renderToString` is pure string work, so **KaTeX no longer ships to the browser at all** — math arrives as prerendered HTML styled by the KaTeX CSS.

**Client JS for a post page: 1.17 MB → 723 KB (−38%).**

No visual changes — same HTML, same CSS.

## Verification
- `next build` clean (42 pages); prerendered HTML spot-checked: KaTeX inline + display markup, heading anchor ids, and formatted dates all present.
- All props crossing the new server→client boundaries are serializable (strings / plain objects).
- `npm run lint` passes.

## Notes
- Worth one manual click-through of a post with a PDF and a code block after deploy: the copy button and Adobe PDF viewer are the two interactive islands.