### PR TITLE
Add RSS feed at /feed.xml

### DIFF
--- a/web/app/feed.xml/route.js
+++ b/web/app/feed.xml/route.js
@@ -1,0 +1,69 @@
+import groq from 'groq';
+import client from '../../client';
+
+const SITE_URL = 'https://www.venugopal.net';
+
+export const revalidate = 3600; // Regenerate at most hourly
+
+function escapeXml(value = '') {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
+async function getPosts() {
+    const query = groq`*[_type == "post" && publishedAt < now() && defined(slug.current)]
+        | order(publishedAt desc)[0...50]{
+            title,
+            subtitle,
+            "slug": slug.current,
+            publishedAt,
+            "categories": categories[]->title,
+            "excerpt": pt::text(body)
+        }`;
+    return client.fetch(query);
+}
+
+export async function GET() {
+    const posts = await getPosts();
+
+    const items = posts
+        .map((post) => {
+            const url = `${SITE_URL}/blog/${post.slug}`;
+            const description = post.subtitle || (post.excerpt || '').substring(0, 300);
+            const categories = (post.categories || [])
+                .map((title) => `<category>${escapeXml(title)}</category>`)
+                .join('');
+            return `        <item>
+            <title>${escapeXml(post.title)}</title>
+            <link>${url}</link>
+            <guid isPermaLink="true">${url}</guid>
+            <pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>
+            <description>${escapeXml(description)}</description>
+            ${categories}
+        </item>`;
+        })
+        .join('\n');
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Kulkarni Venugopal</title>
+        <link>${SITE_URL}</link>
+        <description>Kulkarni Venugopal's Personal Website and Blog</description>
+        <language>en</language>
+        <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+        <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+    </channel>
+</rss>`;
+
+    return new Response(xml, {
+        headers: {
+            'Content-Type': 'application/rss+xml; charset=utf-8',
+        },
+    });
+}

--- a/web/app/layout.js
+++ b/web/app/layout.js
@@ -38,6 +38,11 @@ export const metadata = {
   icons: {
     icon: '/favicon.ico',
   },
+  alternates: {
+    types: {
+      'application/rss+xml': '/feed.xml',
+    },
+  },
   openGraph: {
     title: 'Kulkarni Venugopal',
     description: "Kulkarni Venugopal's Personal Website and Blog",


### PR DESCRIPTION
## What

RSS 2.0 feed at `/feed.xml`, mirroring the sitemap route's pattern:

- 50 most recent published posts (`publishedAt < now()`, same visibility rule as the blog index)
- Each item: title, link, permalink `guid`, `pubDate`, description (subtitle if set, else a 300-char plain-text excerpt), and category tags
- All text XML-escaped; `Content-Type: application/rss+xml`
- ISR: regenerates at most hourly
- `<link rel="alternate" type="application/rss+xml">` in the layout head so feed readers autodiscover it from any page URL

No UI changes, no new dependencies.

## Verification

Built and served locally: feed parses as valid XML with all 22 current posts, correct field values on inspection, correct content type header, and the autodiscovery tag present in rendered HTML.