### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/web/app/layout.js
+++ b/web/app/layout.js
@@ -1,5 +1,6 @@
 import '../styles/globals.css';
 import Navbar from '../components/Navbar';
+import { Analytics } from '@vercel/analytics/next';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import { Raleway, Roboto, Literata } from 'next/font/google';
 
@@ -122,6 +123,7 @@ export default function RootLayout({ children }) {
         <Navbar>
           {children}
         </Navbar>
+        <Analytics />
       </body>
     </html>
   );

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@sanity/asset-utils": "^2.3.0",
         "@sanity/client": "^7.23.0",
         "@sanity/image-url": "^2.1.1",
+        "@vercel/analytics": "^2.0.1",
         "groq": "^6.3.0",
         "katex": "^0.16.22",
         "next": "^16.2.10",
@@ -2064,6 +2065,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "@sanity/asset-utils": "^2.3.0",
     "@sanity/client": "^7.23.0",
     "@sanity/image-url": "^2.1.1",
+    "@vercel/analytics": "^2.0.1",
     "groq": "^6.3.0",
     "katex": "^0.16.22",
     "next": "^16.2.10",


### PR DESCRIPTION
## What

Page-view analytics via `@vercel/analytics` — the option we settled on since the site already deploys on Vercel.

- `<Analytics />` added to the root layout; one dependency, two lines of code
- Cookieless and privacy-friendly: no consent banner needed, nothing stored on visitors' devices
- No-op in development and outside Vercel, so local runs are unaffected

## ⚠️ One manual step required

After merging, enable it in the dashboard or no data will flow: **Vercel → your project → Analytics tab → Enable**. Data appears there within ~30s of the first production visit.

## Verification
- `next build` clean (43 routes), lint passes. The script tag itself only injects in production on Vercel, so the live check is: visit the site after deploy, then look at the Analytics tab.