### PR TITLE
Add first-party PDF SEO pages

### DIFF
--- a/studio/schemas/blockContent.jsx
+++ b/studio/schemas/blockContent.jsx
@@ -95,7 +95,35 @@ export default {
                 withFilename: true,
             },
         },
-        { type: 'file', title: 'PDF' },
+        {
+            type: 'file',
+            title: 'PDF',
+            options: {
+                accept: 'application/pdf',
+            },
+            fields: [
+                {
+                    name: 'title',
+                    title: 'Title',
+                    type: 'string',
+                    description: 'A short readable title for links and search previews.',
+                },
+                {
+                    name: 'description',
+                    title: 'Description',
+                    type: 'text',
+                    rows: 3,
+                    description: 'Optional summary used on the first-party PDF page.',
+                },
+                {
+                    name: 'transcript',
+                    title: 'Text version',
+                    type: 'text',
+                    rows: 12,
+                    description: 'Plain text extracted from the PDF for search and accessibility.',
+                },
+            ],
+        },
         { type: 'latex', icon: mathIcon, title: 'Math block' },
         {
             type: 'poetry',

--- a/web/app/blog/[slug]/page.js
+++ b/web/app/blog/[slug]/page.js
@@ -25,12 +25,19 @@ export const revalidate = 10;
 async function getPost(slug) {
     const query = groq`*[_type == "post" && slug.current == $slug][0]{
       title,
+      "slug": slug.current,
       "authorName": author->name,
       "authorSlug": author->slug.current, // Assuming author has a slug for a potential author page
       "categories": categories[]->{title, "slug": slug.current},
       "date": publishedAt,
       _updatedAt,
-      body,
+      body[]{
+        ...,
+        _type == "file" => {
+          ...,
+          "originalFilename": asset->originalFilename
+        }
+      },
       "metaDescription": pt::text(body), // Or a dedicated metaDescription field
       'previousPost': *[_type == 'post' && publishedAt < ^.publishedAt] | order(publishedAt desc)[0].slug.current,
       'nextPost': *[_type == 'post' && publishedAt > ^.publishedAt] | order(publishedAt asc)[0].slug.current

--- a/web/app/blog/[slug]/pdf/[pdfKey]/page.js
+++ b/web/app/blog/[slug]/pdf/[pdfKey]/page.js
@@ -7,6 +7,7 @@ import FormattedDate from '../../../../../components/FormattedDate';
 import Header from '../../../../../components/Header';
 import PDFViewer from '../../../../../components/PDFViewer/PDFViewer';
 import { pdfPagePath, pdfUrlFromAssetRef } from '../../../../../pdf';
+import { extractPdfText } from '../../../../../pdfText';
 import styles from '../../../../../styles/Post.module.css';
 
 const SITE_URL = 'https://www.venugopal.net';
@@ -45,6 +46,27 @@ async function getPdfPage(slug, pdfKey) {
     return client.fetch(query, { slug, pdfKey });
 }
 
+async function getResolvedPdfPage(slug, pdfKey) {
+    const post = await getPdfPage(slug, pdfKey);
+    const pdfUrl = pdfUrlFromAssetRef(post?.pdf?.assetRef);
+
+    if (!post?.pdf || !pdfUrl) {
+        return post;
+    }
+
+    const storedTranscript = String(post.pdf.transcript || '').trim();
+    const transcript = storedTranscript || await extractPdfText(pdfUrl);
+
+    return {
+        ...post,
+        pdf: {
+            ...post.pdf,
+            pdfUrl,
+            transcript,
+        },
+    };
+}
+
 export async function generateStaticParams() {
     const posts = await client.fetch(
         groq`*[_type == "post" && defined(slug.current)]{
@@ -63,9 +85,9 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }) {
     const { slug, pdfKey } = await params;
-    const post = await getPdfPage(slug, pdfKey);
+    const post = await getResolvedPdfPage(slug, pdfKey);
 
-    if (!post?.pdf?.assetRef) {
+    if (!post?.pdf?.pdfUrl) {
         return {
             title: 'PDF Not Found',
             description: 'The PDF document you are looking for could not be found.',
@@ -106,17 +128,13 @@ export async function generateMetadata({ params }) {
 
 const PdfPage = async ({ params }) => {
     const { slug, pdfKey } = await params;
-    const post = await getPdfPage(slug, pdfKey);
+    const post = await getResolvedPdfPage(slug, pdfKey);
 
-    if (!post?.pdf?.assetRef) {
+    if (!post?.pdf?.pdfUrl) {
         notFound();
     }
 
-    const pdfUrl = pdfUrlFromAssetRef(post.pdf.assetRef);
-    if (!pdfUrl) {
-        notFound();
-    }
-
+    const pdfUrl = post.pdf.pdfUrl;
     const pdfTitle = getPdfTitle(post, post.pdf);
     const description =
         post.pdf.description ||
@@ -178,8 +196,6 @@ const PdfPage = async ({ params }) => {
                     </Link>
                 </div>
 
-                <PDFViewer url={pdfUrl} id={`pdf-${pdfKey}`} />
-
                 {post.pdf.transcript && (
                     <section className={styles.pdfTranscript}>
                         <h2>Text version</h2>
@@ -188,6 +204,11 @@ const PdfPage = async ({ params }) => {
                         </div>
                     </section>
                 )}
+
+                <section className={styles.pdfOriginal}>
+                    <h2>Original PDF</h2>
+                    <PDFViewer url={pdfUrl} id={`pdf-${pdfKey}`} />
+                </section>
             </article>
         </>
     );

--- a/web/app/blog/[slug]/pdf/[pdfKey]/page.js
+++ b/web/app/blog/[slug]/pdf/[pdfKey]/page.js
@@ -1,0 +1,196 @@
+import groq from 'groq';
+import Link from 'next/link';
+import Script from 'next/script';
+import { notFound } from 'next/navigation';
+import client from '../../../../../client';
+import FormattedDate from '../../../../../components/FormattedDate';
+import Header from '../../../../../components/Header';
+import PDFViewer from '../../../../../components/PDFViewer/PDFViewer';
+import { pdfPagePath, pdfUrlFromAssetRef } from '../../../../../pdf';
+import styles from '../../../../../styles/Post.module.css';
+
+const SITE_URL = 'https://www.venugopal.net';
+
+export const revalidate = 10;
+
+function textExcerpt(text = '', maxLength = 160) {
+    const normalized = text.replace(/\s+/g, ' ').trim();
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+
+    return `${normalized.slice(0, maxLength - 3).trim()}...`;
+}
+
+function getPdfTitle(post, pdf) {
+    return pdf?.title || pdf?.originalFilename || `${post.title} PDF`;
+}
+
+async function getPdfPage(slug, pdfKey) {
+    const query = groq`*[_type == "post" && slug.current == $slug][0]{
+      title,
+      "slug": slug.current,
+      "authorName": author->name,
+      "date": publishedAt,
+      _updatedAt,
+      "pdf": body[_type == "file" && _key == $pdfKey][0]{
+        _key,
+        title,
+        description,
+        transcript,
+        "assetRef": asset._ref,
+        "originalFilename": asset->originalFilename
+      }
+    }`;
+    return client.fetch(query, { slug, pdfKey });
+}
+
+export async function generateStaticParams() {
+    const posts = await client.fetch(
+        groq`*[_type == "post" && defined(slug.current)]{
+          "slug": slug.current,
+          "pdfKeys": body[_type == "file" && defined(asset._ref)]._key
+        }`
+    );
+
+    return posts.flatMap((post) =>
+        (post.pdfKeys || []).map((pdfKey) => ({
+            slug: post.slug,
+            pdfKey,
+        }))
+    );
+}
+
+export async function generateMetadata({ params }) {
+    const { slug, pdfKey } = await params;
+    const post = await getPdfPage(slug, pdfKey);
+
+    if (!post?.pdf?.assetRef) {
+        return {
+            title: 'PDF Not Found',
+            description: 'The PDF document you are looking for could not be found.',
+        };
+    }
+
+    const title = getPdfTitle(post, post.pdf);
+    const description =
+        post.pdf.description ||
+        textExcerpt(post.pdf.transcript) ||
+        `PDF document from ${post.title}.`;
+    const canonicalPath = pdfPagePath(slug, pdfKey);
+    const canonicalUrl = `${SITE_URL}${canonicalPath}`;
+
+    return {
+        title: `${title} | ${post.title}`,
+        description,
+        alternates: {
+            canonical: canonicalUrl,
+        },
+        openGraph: {
+            title,
+            description,
+            url: canonicalUrl,
+            type: 'article',
+            publishedTime: post.date,
+            modifiedTime: post._updatedAt,
+            authors: post.authorName ? [post.authorName] : [],
+        },
+        twitter: {
+            card: 'summary',
+            title,
+            description,
+            creator: '@_Vorld',
+        },
+    };
+}
+
+const PdfPage = async ({ params }) => {
+    const { slug, pdfKey } = await params;
+    const post = await getPdfPage(slug, pdfKey);
+
+    if (!post?.pdf?.assetRef) {
+        notFound();
+    }
+
+    const pdfUrl = pdfUrlFromAssetRef(post.pdf.assetRef);
+    if (!pdfUrl) {
+        notFound();
+    }
+
+    const pdfTitle = getPdfTitle(post, post.pdf);
+    const description =
+        post.pdf.description ||
+        textExcerpt(post.pdf.transcript) ||
+        `PDF document from ${post.title}.`;
+    const pagePath = pdfPagePath(slug, pdfKey);
+    const pageUrl = `${SITE_URL}${pagePath}`;
+    const postUrl = `${SITE_URL}/blog/${slug}`;
+    const pdfSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'DigitalDocument',
+        name: pdfTitle,
+        description,
+        url: pageUrl,
+        encodingFormat: 'application/pdf',
+        isPartOf: {
+            '@type': 'BlogPosting',
+            headline: post.title,
+            url: postUrl,
+        },
+        associatedMedia: {
+            '@type': 'MediaObject',
+            contentUrl: pdfUrl,
+            encodingFormat: 'application/pdf',
+        },
+        datePublished: post.date,
+        dateModified: post._updatedAt,
+    };
+
+    return (
+        <>
+            <Script
+                id="pdf-schema"
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(pdfSchema) }}
+            />
+            <Header heading={'PDF'} />
+
+            <article className={styles.container}>
+                <Link href={`/blog/${slug}`} className={styles.return}>
+                    Back to post
+                </Link>
+                <h1 className={styles.title}>{pdfTitle}</h1>
+                <h5 className={styles.name}>From {post.title}</h5>
+                <span className={styles.date}>
+                    <FormattedDate date={post.date} />
+                </span>
+
+                {post.pdf.description && (
+                    <p className={styles.pdfDescription}>{post.pdf.description}</p>
+                )}
+
+                <div className={styles.pdfActions}>
+                    <a href={pdfUrl} className={styles.pdfAction}>
+                        Download original PDF
+                    </a>
+                    <Link href={`/blog/${slug}`} className={styles.pdfAction}>
+                        Read the post
+                    </Link>
+                </div>
+
+                <PDFViewer url={pdfUrl} id={`pdf-${pdfKey}`} />
+
+                {post.pdf.transcript && (
+                    <section className={styles.pdfTranscript}>
+                        <h2>Text version</h2>
+                        <div className={styles.pdfTranscriptText}>
+                            {post.pdf.transcript}
+                        </div>
+                    </section>
+                )}
+            </article>
+        </>
+    );
+};
+
+export default PdfPage;

--- a/web/app/blog/[slug]/pdf/[pdfKey]/page.js
+++ b/web/app/blog/[slug]/pdf/[pdfKey]/page.js
@@ -14,7 +14,7 @@ const SITE_URL = 'https://www.venugopal.net';
 export const revalidate = 10;
 
 function textExcerpt(text = '', maxLength = 160) {
-    const normalized = text.replace(/\s+/g, ' ').trim();
+    const normalized = String(text || '').replace(/\s+/g, ' ').trim();
     if (normalized.length <= maxLength) {
         return normalized;
     }

--- a/web/app/sitemap.xml/route.js
+++ b/web/app/sitemap.xml/route.js
@@ -1,4 +1,5 @@
 import client from '../../client'; 
+import { pdfPagePath } from '../../pdf';
 
 
 const SITE_URL = 'https://www.venugopal.net';
@@ -19,9 +20,11 @@ async function getAllCategorySlugs() {
 }
 
 async function getAllPdfAssets() {
-  // Fetches all PDF file assets from posts
+  // Fetches all PDF blocks from posts so their first-party wrapper pages
+  // can be listed instead of raw Sanity CDN asset URLs.
   const query = `*[_type == "post"]{
-    "pdfs": body[_type == "file"]{
+    "pdfs": body[_type == "file" && defined(asset._ref)]{
+      "pdfKey": _key,
       "ref": asset._ref,
       "postSlug": ^.slug.current,
       "postUpdatedAt": ^._updatedAt
@@ -31,7 +34,7 @@ async function getAllPdfAssets() {
 
   // Flatten and filter to get all PDFs
   const pdfs = posts.flatMap(post => post.pdfs || [])
-                    .filter(pdf => pdf.ref);
+                    .filter(pdf => pdf.ref && pdf.pdfKey && pdf.postSlug);
 
   return pdfs;
 }
@@ -94,11 +97,10 @@ export async function GET() {
         .join('')}
       ${allPdfs
         .map((pdf) => {
-          const [_file, id, extension] = pdf.ref.split('-');
-          const pdfUrl = `https://cdn.sanity.io/files/qjy3hvt5/production/${id}.${extension}`;
+          const pdfPageUrl = `${SITE_URL}${pdfPagePath(pdf.postSlug, pdf.pdfKey)}`;
           return `
             <url>
-              <loc>${pdfUrl}</loc>
+              <loc>${pdfPageUrl}</loc>
               <lastmod>${new Date(pdf.postUpdatedAt).toISOString().split('T')[0]}</lastmod>
               <priority>0.6</priority>
             </url>

--- a/web/components/PostContent.js
+++ b/web/components/PostContent.js
@@ -106,7 +106,7 @@ const createPtComponents = (postSlug) => ({
                     <div className={styles.pdfActions}>
                         {pdfPageHref && (
                             <Link href={pdfPageHref} className={styles.pdfAction}>
-                                Open text version
+                                Open searchable PDF page
                             </Link>
                         )}
                         <a href={url} className={styles.pdfAction}>

--- a/web/components/PostContent.js
+++ b/web/components/PostContent.js
@@ -15,6 +15,7 @@ import Header from './Header'; // Corrected path
 import FormattedDate from './FormattedDate'; // Corrected path
 import PDFViewer from './PDFViewer/PDFViewer'; // Corrected path
 import CodeBlock from './CodeBlock';
+import { pdfPagePath, pdfUrlFromAssetRef } from '../pdf';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
 
@@ -40,7 +41,7 @@ const heading = (Tag) => {
 };
 
 // All custom ptComponents
-const ptComponents = {
+const createPtComponents = (postSlug) => ({
     block: {
         h1: heading('h1'),
         h2: heading('h2'),
@@ -90,40 +91,34 @@ const ptComponents = {
         // PDFViewer is a client component
         file: ({ value }) => {
             if (!value?.asset?._ref) return null;
-            const { _ref } = value.asset;
-            const [_file, id, extension] = _ref.split('-');
-            const url =
-                'https://cdn.sanity.io/files/qjy3hvt5/production/' +
-                id +
-                '.' +
-                extension;
+            const url = pdfUrlFromAssetRef(value.asset._ref);
+            if (!url) return null;
+
+            const pdfTitle = value.title || value.originalFilename || 'PDF document';
+            const pdfPageHref = pdfPagePath(postSlug, value._key);
+            const pdfViewerId = value._key
+                ? `pdf-${value._key}`
+                : value.asset._ref.replace(/[^a-zA-Z0-9_-]/g, '-');
 
             return (
-                <>
-                    {/* PDF URL link for SEO - hidden from view but in DOM */}
-                    <a
-                        href={url}
-                        aria-label="Download PDF document"
-                        style={{
-                            position: 'absolute',
-                            width: '1px',
-                            height: '1px',
-                            padding: 0,
-                            margin: '-1px',
-                            overflow: 'hidden',
-                            clip: 'rect(0,0,0,0)',
-                            whiteSpace: 'nowrap',
-                            border: 0
-                        }}
-                    >
-                        View PDF Document
-                    </a>
-                    <PDFViewer url={url} id={id} />
-                </>
+                <figure className={styles.pdfBlock}>
+                    <figcaption className={styles.pdfCaption}>{pdfTitle}</figcaption>
+                    <div className={styles.pdfActions}>
+                        {pdfPageHref && (
+                            <Link href={pdfPageHref} className={styles.pdfAction}>
+                                Open text version
+                            </Link>
+                        )}
+                        <a href={url} className={styles.pdfAction}>
+                            Download PDF
+                        </a>
+                    </div>
+                    <PDFViewer url={url} id={pdfViewerId} />
+                </figure>
             );
         },
     },
-};
+});
 
 
 const PostContent = ({ post }) => {
@@ -134,6 +129,7 @@ const PostContent = ({ post }) => {
     const {
         title = 'Missing title',
         authorName = 'Missing author name',
+        slug,
         categories,
         date,
         body = [],
@@ -157,7 +153,7 @@ const PostContent = ({ post }) => {
                 </span>
 
                 <div className={styles.body}>
-                    <ReactPortableText value={body} components={ptComponents} />
+                    <ReactPortableText value={body} components={createPtComponents(slug)} />
                 </div>
 
                 <span className={styles.categories}>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "groq": "^6.3.0",
         "katex": "^0.16.22",
         "next": "^16.2.10",
+        "pdf-parse": "^2.4.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-syntax-highlighter": "^16.1.1"
@@ -1139,6 +1140,190 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5680,6 +5865,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/picocolors": {

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "groq": "^6.3.0",
     "katex": "^0.16.22",
     "next": "^16.2.10",
+    "pdf-parse": "^2.4.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-syntax-highlighter": "^16.1.1"

--- a/web/pdf.js
+++ b/web/pdf.js
@@ -1,0 +1,26 @@
+const SANITY_PROJECT_ID = 'qjy3hvt5';
+const SANITY_DATASET = 'production';
+
+export function pdfUrlFromAssetRef(assetRef) {
+    if (!assetRef) {
+        return null;
+    }
+
+    const parts = assetRef.split('-');
+    if (parts[0] !== 'file' || parts.length < 3) {
+        return null;
+    }
+
+    const extension = parts.at(-1);
+    const id = parts.slice(1, -1).join('-');
+
+    return `https://cdn.sanity.io/files/${SANITY_PROJECT_ID}/${SANITY_DATASET}/${id}.${extension}`;
+}
+
+export function pdfPagePath(postSlug, pdfKey) {
+    if (!postSlug || !pdfKey) {
+        return null;
+    }
+
+    return `/blog/${encodeURIComponent(postSlug)}/pdf/${encodeURIComponent(pdfKey)}`;
+}

--- a/web/pdfText.js
+++ b/web/pdfText.js
@@ -1,0 +1,43 @@
+import { cache } from 'react';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { PDFParse } from 'pdf-parse';
+
+const pdfWorkerPath = path.join(
+    process.cwd(),
+    'node_modules',
+    'pdfjs-dist',
+    'legacy',
+    'build',
+    'pdf.worker.mjs'
+);
+
+PDFParse.setWorker(pathToFileURL(pdfWorkerPath).toString());
+
+function normalizePdfText(text) {
+    return String(text || '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+export const extractPdfText = cache(async (pdfUrl) => {
+    if (!pdfUrl) {
+        return '';
+    }
+
+    let parser;
+
+    try {
+        parser = new PDFParse({ url: pdfUrl });
+        const result = await parser.getText();
+        return normalizePdfText(result.text);
+    } catch (error) {
+        console.warn(`Unable to extract PDF text from ${pdfUrl}`, error);
+        return '';
+    } finally {
+        if (parser) {
+            await parser.destroy().catch(() => {});
+        }
+    }
+});

--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -314,6 +314,17 @@
   color: #e0e0e0;
 }
 
+.pdfOriginal {
+  margin-top: 2rem;
+}
+
+.pdfOriginal h2 {
+  margin: 0 0 1rem;
+  font-family: var(--font-literata), Georgia, serif;
+  font-size: 1.5rem;
+  color: #f0f0f0;
+}
+
 .categories a {
   font-weight: 300;
   font-size: 1rem;

--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -254,6 +254,66 @@
   text-decoration-color: #e0e0e0;
 }
 
+.pdfBlock {
+  margin: 2em 0;
+}
+
+.pdfCaption {
+  margin-bottom: 0.5rem;
+  font-family: var(--font-raleway), Arial, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.pdfActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0;
+  font-family: var(--font-raleway), Arial, sans-serif;
+  font-size: 0.95rem;
+}
+
+.pdfAction {
+  color: #e0e0e0;
+  text-decoration: underline;
+  text-decoration-color: #808080;
+  text-underline-offset: 2px;
+}
+
+.pdfAction:hover {
+  text-decoration-color: #e0e0e0;
+}
+
+.pdfDescription {
+  margin-top: 1.5rem;
+  font-family: var(--font-literata), Georgia, serif;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: #d8d8d8;
+}
+
+.pdfTranscript {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #3a3a3a;
+  font-family: var(--font-literata), Georgia, serif;
+}
+
+.pdfTranscript h2 {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  color: #f0f0f0;
+}
+
+.pdfTranscriptText {
+  white-space: pre-wrap;
+  font-size: 1.1rem;
+  line-height: 1.65;
+  color: #e0e0e0;
+}
+
 .categories a {
   font-weight: 300;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add Sanity PDF metadata fields for title, description, and optional text overrides
- add first-party /blog/[slug]/pdf/[pdfKey] pages that render extracted PDF text plus the original embedded PDF
- auto-extract text from Sanity PDF assets when no Sanity transcript is provided
- link blog PDF blocks to their searchable first-party pages and list those pages in the sitemap instead of raw Sanity CDN URLs

## Tests
- npm run lint (passes with pre-existing warnings in Navbar.js and Typewriter.js)
- npm run build
- confirmed generated HTML for /blog/ib-physics-internal-assessment/pdf/452b72e4f206 contains extracted PDF text and text-derived metadata