### PR TITLE
Serve blog PDFs from own domain for SEO indexing

### DIFF
--- a/web/app/pdfs/[filename]/route.js
+++ b/web/app/pdfs/[filename]/route.js
@@ -1,0 +1,33 @@
+import client from '../../../client';
+
+// PDFs live on the Sanity CDN, whose robots.txt blocks crawlers from *.pdf.
+// Serving them from our own domain lets search engines index their contents
+// and attribute them to this site.
+export async function GET(request, { params }) {
+    const { filename } = await params;
+
+    // Asset filenames are "<hash>.pdf"; reject anything else so this route
+    // doesn't become an open proxy for the whole Sanity project
+    if (!/^[a-z0-9]+\.pdf$/i.test(filename)) {
+        return new Response('Not found', { status: 404 });
+    }
+
+    const { projectId, dataset } = client.config();
+    const upstream = await fetch(
+        `https://cdn.sanity.io/files/${projectId}/${dataset}/${filename}`
+    );
+    if (!upstream.ok) {
+        return new Response('Not found', { status: 404 });
+    }
+
+    return new Response(upstream.body, {
+        headers: {
+            'Content-Type': 'application/pdf',
+            'Content-Disposition': 'inline',
+            // Sanity file URLs are content-addressed, so the bytes never change
+            'Cache-Control': 'public, max-age=31536000, immutable',
+            // The Adobe viewer fetches the PDF from its own iframe origin
+            'Access-Control-Allow-Origin': '*',
+        },
+    });
+}

--- a/web/app/sitemap.xml/route.js
+++ b/web/app/sitemap.xml/route.js
@@ -1,4 +1,5 @@
-import client from '../../client'; 
+import client from '../../client';
+import { pdfPathFromRef } from '../../lib/pdf';
 
 
 const SITE_URL = 'https://www.venugopal.net';
@@ -94,8 +95,7 @@ export async function GET() {
         .join('')}
       ${allPdfs
         .map((pdf) => {
-          const [_file, id, extension] = pdf.ref.split('-');
-          const pdfUrl = `https://cdn.sanity.io/files/qjy3hvt5/production/${id}.${extension}`;
+          const pdfUrl = `${SITE_URL}${pdfPathFromRef(pdf.ref)}`;
           return `
             <url>
               <loc>${pdfUrl}</loc>

--- a/web/components/PDFViewer/ViewSDKClient.js
+++ b/web/components/PDFViewer/ViewSDKClient.js
@@ -36,9 +36,11 @@ class ViewSDKClient {
             {
                 /* Pass information on how to access the file */
                 content: {
-                    /* Location of file where it is hosted */
+                    /* Location of file where it is hosted. Adobe fetches it
+                    from an iframe on its own origin, so a same-site relative
+                    path must be resolved to an absolute URL first */
                     location: {
-                        url: url,
+                        url: new URL(url, window.location.origin).href,
                         /*
                     If the file URL requires some additional headers, then it can be passed as follows:-
                     headers: [

--- a/web/components/PostContent.js
+++ b/web/components/PostContent.js
@@ -14,6 +14,7 @@ import Image from 'next/image';
 import Header from './Header'; // Corrected path
 import FormattedDate from './FormattedDate'; // Corrected path
 import PDFViewer from './PDFViewer/PDFViewer'; // Corrected path
+import { pdfPathFromRef } from '../lib/pdf';
 import CodeBlock from './CodeBlock';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
@@ -91,34 +92,15 @@ const ptComponents = {
         file: ({ value }) => {
             if (!value?.asset?._ref) return null;
             const { _ref } = value.asset;
-            const [_file, id, extension] = _ref.split('-');
-            const url =
-                'https://cdn.sanity.io/files/qjy3hvt5/production/' +
-                id +
-                '.' +
-                extension;
+            const [_file, id] = _ref.split('-');
+            const url = pdfPathFromRef(_ref);
 
             return (
                 <>
-                    {/* PDF URL link for SEO - hidden from view but in DOM */}
-                    <a
-                        href={url}
-                        aria-label="Download PDF document"
-                        style={{
-                            position: 'absolute',
-                            width: '1px',
-                            height: '1px',
-                            padding: 0,
-                            margin: '-1px',
-                            overflow: 'hidden',
-                            clip: 'rect(0,0,0,0)',
-                            whiteSpace: 'nowrap',
-                            border: 0
-                        }}
-                    >
-                        View PDF Document
-                    </a>
                     <PDFViewer url={url} id={id} />
+                    <a href={url} className={styles.pdfLink} target="_blank">
+                        Open PDF
+                    </a>
                 </>
             );
         },

--- a/web/lib/pdf.js
+++ b/web/lib/pdf.js
@@ -1,0 +1,7 @@
+// Sanity file asset refs look like "file-<hash>-pdf". PDFs are served
+// through /pdfs/[filename] so crawlers index them under our domain instead
+// of cdn.sanity.io, whose robots.txt disallows *.pdf.
+export function pdfPathFromRef(ref) {
+    const [, id, extension] = ref.split('-');
+    return `/pdfs/${id}.${extension}`;
+}

--- a/web/styles/Post.module.css
+++ b/web/styles/Post.module.css
@@ -303,6 +303,14 @@
   text-align: center;
 }
 
+.pdfLink {
+  display: block;
+  margin: 0.5em 0 1.5em;
+  font-size: 0.9rem;
+  color: #b0b0b0;
+  text-align: center;
+}
+
 @media only screen and (min-width: 768px) {
   .return:hover::before {
     opacity: 0;


### PR DESCRIPTION
## Why

PDFs embedded in blog posts are served straight from `cdn.sanity.io`, and Sanity's robots.txt contains `Disallow: /*.pdf` — so search engines are forbidden from ever reading them. The sitemap's PDF entries were also cross-domain (sitemaps may only list same-host URLs), so they were silently ignored. Net effect: none of the PDF content contributed to the site's SEO.

## What

- **New `/pdfs/[filename]` route** that proxies the file from the Sanity CDN under `venugopal.net`. Validates the filename (only `<hash>.pdf`), sets `Cache-Control: immutable` (Sanity file URLs are content-addressed, so Vercel's edge cache absorbs repeat/crawler traffic instead of Sanity bandwidth), `Content-Disposition: inline`, and CORS for the Adobe viewer.
- **Shared `pdfPathFromRef` helper** (`web/lib/pdf.js`) replaces the CDN URL construction previously duplicated in `PostContent.js` and the sitemap route.
- **Sitemap** now emits `https://www.venugopal.net/pdfs/<hash>.pdf` — valid same-domain entries that Google will actually crawl.
- **Visible "Open PDF" link** (small, caption-styled, centered under the viewer) replaces the old visually-hidden anchor — hidden links carry little SEO weight and pattern-match to cloaking.
- **ViewSDKClient** resolves the now-relative PDF path to an absolute URL, since Adobe fetches the file from an iframe on its own origin.

## Verified

Built and ran the production server locally:
- `GET /pdfs/e9f1d9….pdf` → 200, `application/pdf`, `%PDF-1.5` bytes, correct cache/CORS headers
- Traversal and non-PDF filenames → 404
- Sitemap lists all 17 PDFs as `venugopal.net/pdfs/…` URLs
- Post pages render the visible `/pdfs/…` link

Worth confirming on the Vercel preview that the Adobe viewer still renders (it should — same page origin — but the Adobe client ID is domain-registered, so it can't be exercised on localhost).