### PR TITLE
Canonicalize PDFs to their embedding blog post

### DIFF
--- a/web/app/pdfs/[filename]/route.js
+++ b/web/app/pdfs/[filename]/route.js
@@ -1,4 +1,7 @@
+import groq from 'groq';
 import client from '../../../client';
+
+const SITE_URL = 'https://www.venugopal.net';
 
 // PDFs live on the Sanity CDN, whose robots.txt blocks crawlers from *.pdf.
 // Serving them from our own domain lets search engines index their contents
@@ -13,21 +16,30 @@ export async function GET(request, { params }) {
     }
 
     const { projectId, dataset } = client.config();
-    const upstream = await fetch(
-        `https://cdn.sanity.io/files/${projectId}/${dataset}/${filename}`
-    );
+    const [upstream, postSlug] = await Promise.all([
+        fetch(`https://cdn.sanity.io/files/${projectId}/${dataset}/${filename}`),
+        client.fetch(
+            groq`*[_type == "post" && $ref in body[_type == "file"].asset._ref][0].slug.current`,
+            { ref: `file-${filename.replace('.', '-')}` }
+        ),
+    ]);
     if (!upstream.ok) {
         return new Response('Not found', { status: 404 });
     }
 
-    return new Response(upstream.body, {
-        headers: {
-            'Content-Type': 'application/pdf',
-            'Content-Disposition': 'inline',
-            // Sanity file URLs are content-addressed, so the bytes never change
-            'Cache-Control': 'public, max-age=31536000, immutable',
-            // The Adobe viewer fetches the PDF from its own iframe origin
-            'Access-Control-Allow-Origin': '*',
-        },
-    });
+    const headers = {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'inline',
+        // Sanity file URLs are content-addressed, so the bytes never change
+        'Cache-Control': 'public, max-age=31536000, immutable',
+        // The Adobe viewer fetches the PDF from its own iframe origin
+        'Access-Control-Allow-Origin': '*',
+    };
+    // Ask search engines to consolidate the PDF's ranking signals into the
+    // blog post that embeds it, so searches land on the post instead
+    if (postSlug) {
+        headers['Link'] = `<${SITE_URL}/blog/${postSlug}>; rel="canonical"`;
+    }
+
+    return new Response(upstream.body, { headers });
 }

--- a/web/app/sitemap.xml/route.js
+++ b/web/app/sitemap.xml/route.js
@@ -1,5 +1,4 @@
 import client from '../../client';
-import { pdfPathFromRef } from '../../lib/pdf';
 
 
 const SITE_URL = 'https://www.venugopal.net';
@@ -19,28 +18,9 @@ async function getAllCategorySlugs() {
   return categories;
 }
 
-async function getAllPdfAssets() {
-  // Fetches all PDF file assets from posts
-  const query = `*[_type == "post"]{
-    "pdfs": body[_type == "file"]{
-      "ref": asset._ref,
-      "postSlug": ^.slug.current,
-      "postUpdatedAt": ^._updatedAt
-    }
-  }`;
-  const posts = await client.fetch(query);
-
-  // Flatten and filter to get all PDFs
-  const pdfs = posts.flatMap(post => post.pdfs || [])
-                    .filter(pdf => pdf.ref);
-
-  return pdfs;
-}
-
 export async function GET() {
   const allPosts = await getAllPostSlugs();
   const allCategories = await getAllCategorySlugs();
-  const allPdfs = await getAllPdfAssets();
 
   const staticPages = [
     { path: '', lastModified: new Date().toISOString(), priority: 1.0 }, // Homepage
@@ -89,18 +69,6 @@ export async function GET() {
               <loc>${SITE_URL}/blog/category/${category.slug}</loc>
               <lastmod>${new Date(category._updatedAt).toISOString().split('T')[0]}</lastmod>
               <priority>0.7</priority>
-            </url>
-          `;
-        })
-        .join('')}
-      ${allPdfs
-        .map((pdf) => {
-          const pdfUrl = `${SITE_URL}${pdfPathFromRef(pdf.ref)}`;
-          return `
-            <url>
-              <loc>${pdfUrl}</loc>
-              <lastmod>${new Date(pdf.postUpdatedAt).toISOString().split('T')[0]}</lastmod>
-              <priority>0.6</priority>
             </url>
           `;
         })


### PR DESCRIPTION
Follow-up to #25. Goal: searches that match PDF content should land on the blog post (with the embedded viewer), not the raw PDF file.

## What

- **`/pdfs/[filename]` now sends a canonical Link header** pointing at the post that embeds the PDF, e.g. `Link: <https://www.venugopal.net/blog/ib-physics-internal-assessment>; rel="canonical"`. This is Google's documented mechanism for consolidating a non-HTML duplicate (like a PDF) into its HTML page. The post slug is resolved with a GROQ lookup by asset ref, run in parallel with the CDN fetch so it adds no latency; PDFs not embedded in any post get no header. The response (header included) is still edge-cached as immutable.
- **Sitemap no longer lists the PDFs.** Sitemap entries are themselves a canonicalization signal, so listing the PDF URLs would contradict the header. The PDFs remain crawlable/discoverable via the visible "Open PDF" link on each post.

## Caveat

`rel=canonical` is a hint, not a directive — Google can ignore it if it doesn't consider the PDF and the post near-duplicates. Search Console's URL Inspection will show which canonical Google actually selected for the `/pdfs/…` URLs, so we'll know if it took.

## Verified

Built and ran the production server locally:
- Two PDFs from different posts each return the correct canonical Link header for their embedding post
- Sitemap contains zero `/pdfs/` entries; the other 40 URLs are unchanged
- Cache/CORS/content-type headers unchanged