### PR TITLE
Fix mobile viewport styling

### DIFF
--- a/web/styles/Home.module.css
+++ b/web/styles/Home.module.css
@@ -218,6 +218,13 @@
     height: 100lvh;     
     box-sizing: border-box; /* Ensure padding/border don't add to height */
   }
+
+  .section1 {
+    height: auto;
+    min-height: 100lvh;
+    justify-content: flex-start;
+    padding-block: clamp(3rem, 8lvh, 5rem);
+  }
   
   .socialIcons {
     gap: 1rem;
@@ -245,8 +252,9 @@
   
   .authorText {
     width: 100%;
+    max-height: none;
+    overflow-y: visible;
     /* text-align and align-items removed for mobile, rely on parent's align-items:center */
     /* and its own justify-content: center if needed, though for column it might not be the primary effect */
   }
 }
-

--- a/web/styles/Home.module.css
+++ b/web/styles/Home.module.css
@@ -206,24 +206,29 @@
 
 @media only screen and (max-width: 767px) {
   .landing {
-    min-height: 100lvh; 
-    height: 100lvh;    
+    min-height: 100vh;
+    min-height: 100dvh; 
+    height: 100vh;
+    height: 100dvh;    
     box-sizing: border-box; /* Ensure padding/border don't add to height */
   }
 
   .para {
     letter-spacing: 0.005em;
     padding: 0% 10% 0% 10%;
-    min-height: 100lvh; 
-    height: 100lvh;     
+    min-height: 100vh;
+    min-height: 100dvh; 
+    height: 100vh;
+    height: 100dvh;     
     box-sizing: border-box; /* Ensure padding/border don't add to height */
   }
 
   .section1 {
     height: auto;
-    min-height: 100lvh;
+    min-height: 100vh;
+    min-height: 100dvh;
     justify-content: flex-start;
-    padding-block: clamp(3rem, 8lvh, 5rem);
+    padding-block: clamp(3rem, 8dvh, 5rem);
   }
   
   .socialIcons {

--- a/web/styles/components/Navbar.module.css
+++ b/web/styles/components/Navbar.module.css
@@ -77,11 +77,14 @@
 @media only screen and (max-width: 767px) {
   .main-nav {
     height: 100vh;
+    height: 100dvh;
+    transition: transform 0.4s cubic-bezier(0.77, 0, 0.175, 1),
+      opacity 0.4s cubic-bezier(0.77, 0, 0.175, 1);
   }
 
   .main-nav.close {
-    margin-top: -100vh;
-    transform: translateY(75px);
+    margin-top: 0;
+    transform: translateY(-100%);
     opacity: 0;
   }
 
@@ -112,7 +115,7 @@
   margin-left: -25px;
   margin-top: 25px;
 
-  transition: transform 0.1s, margin-top 0.25s ease, opacity 0.25s ease;
+  transition: transform 0.25s ease, opacity 0.25s ease;
   animation: fadein 1s;
 
   /* Removing annoying blue highlight on tap */
@@ -196,7 +199,7 @@
 }
 
 .menu-button-hide {
-  margin-top: -50px;
+  transform: translateY(-75px);
   opacity: 0;
 }
 
@@ -315,7 +318,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  padding: 20px;
+  padding: 20px 20px calc(20px + env(safe-area-inset-bottom, 0px));
   list-style: none;
 }
 


### PR DESCRIPTION
## Summary
- Fix mobile nav overlay sizing with dynamic viewport units so Android Chrome browser UI does not cover bottom links.
- Replace mobile home-section large viewport sizing with dynamic viewport sizing.
- Move mobile hide animations off margin-based layout changes.

## Test plan
- npm run lint (passes with existing warnings in Navbar.js and Typewriter.js)